### PR TITLE
upgrade to GA durable functions; bugfixes

### DIFF
--- a/actor-circuitbreaker/OpenCircuitOrchestrator.cs
+++ b/actor-circuitbreaker/OpenCircuitOrchestrator.cs
@@ -12,15 +12,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Hollan.Function
 {
-    public class CloseCircuitOrchestrator
+    public class OpenCircuitOrchestrator
     {
         
-        [FunctionName(nameof(CloseCircuitOrchestrator.CloseCircuit))]
-        public async Task CloseCircuit(
+        [FunctionName(nameof(OpenCircuit))]
+        public async Task OpenCircuit(
             [OrchestrationTrigger] IDurableOrchestrationContext context,
             ILogger log)
         {
-            if(!context.IsReplaying) log.LogInformation("Disabling function app to close circuit");
+            if(!context.IsReplaying) log.LogInformation("Disabling function app to open circuit");
 
             var resourceId = context.GetInput<string>();
 
@@ -28,8 +28,10 @@ namespace Hollan.Function
                 HttpMethod.Post, 
                 new Uri($"https://management.azure.com{resourceId}/stop?api-version=2016-08-01"),
                 tokenSource: new ManagedIdentityTokenSource("https://management.core.windows.net"));
-            DurableHttpResponse restartResponse = await context.CallHttpAsync(stopFunctionRequest);
-            if (restartResponse.StatusCode != HttpStatusCode.OK)
+            
+             DurableHttpResponse restartResponse = await context.CallHttpAsync(stopFunctionRequest);
+            
+             if (restartResponse.StatusCode != HttpStatusCode.OK)
             {
                 throw new ArgumentException($"Failed to stop Function App: {restartResponse.StatusCode}: {restartResponse.Content}");
             }

--- a/actor-circuitbreaker/Properties/launchSettings.json
+++ b/actor-circuitbreaker/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "actor-circuitbreaker": {
+      "commandName": "Project",
+      "commandLineArgs": "host start --pause-on-error --port 7070"
+    }
+  }
+}

--- a/actor-circuitbreaker/actor-circuitbreaker.csproj
+++ b/actor-circuitbreaker/actor-circuitbreaker.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
     <RootNamespace>functions_csharp_durable_actor_circuitbreaker</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.0.0-beta2" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.28" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <ProjectReference Include="../circuit-library/circuit-library.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/actor-circuitbreaker/host.json
+++ b/actor-circuitbreaker/host.json
@@ -1,13 +1,8 @@
 {
-    "version": "2.0",
-    "extensions": {
-      "durableTask": {
-        "hubName": "debug12",
-        "storageProvider": {
-          "azureStorage": {
-              "connectionStringName": "AzureWebJobsStorage"
-          }
-        }
-      }
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "Default": "Information"
     }
   }
+}

--- a/actor-circuitbreaker/local.settings.json.sample
+++ b/actor-circuitbreaker/local.settings.json.sample
@@ -1,9 +1,9 @@
 {
-    "IsEncrypted": false,
-    "Values": {
-      "AzureWebJobsStorage": "<storage connection string>",
-      "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-      "FailureThreshold": "5",
-      "WindowSize": "00:00:30"
-    }
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    "FailureThreshold": "5",
+    "WindowSize": "00:00:30"
+  }
 }

--- a/circuitbreaker.sln
+++ b/circuitbreaker.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29505.145
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "actor-circuitbreaker", "actor-circuitbreaker\actor-circuitbreaker.csproj", "{A2EB218A-9EEF-42C5-AAF6-D8CCF9258A98}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "circuit-library", "circuit-library\circuit-library.csproj", "{FBB08F29-3476-4AB3-9F6A-CED7378F99F6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "eventhub-function", "eventhub-function\eventhub-function.csproj", "{8EBF686E-D638-480F-8E1F-E50A99F0E5EE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "eventhub-publisher", "eventhub-publisher\eventhub-publisher.csproj", "{CC9BD4F3-55F1-4AEC-A44D-DAE809896A33}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A2EB218A-9EEF-42C5-AAF6-D8CCF9258A98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2EB218A-9EEF-42C5-AAF6-D8CCF9258A98}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2EB218A-9EEF-42C5-AAF6-D8CCF9258A98}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2EB218A-9EEF-42C5-AAF6-D8CCF9258A98}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBB08F29-3476-4AB3-9F6A-CED7378F99F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBB08F29-3476-4AB3-9F6A-CED7378F99F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBB08F29-3476-4AB3-9F6A-CED7378F99F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBB08F29-3476-4AB3-9F6A-CED7378F99F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8EBF686E-D638-480F-8E1F-E50A99F0E5EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8EBF686E-D638-480F-8E1F-E50A99F0E5EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8EBF686E-D638-480F-8E1F-E50A99F0E5EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8EBF686E-D638-480F-8E1F-E50A99F0E5EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC9BD4F3-55F1-4AEC-A44D-DAE809896A33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC9BD4F3-55F1-4AEC-A44D-DAE809896A33}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC9BD4F3-55F1-4AEC-A44D-DAE809896A33}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC9BD4F3-55F1-4AEC-A44D-DAE809896A33}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AF256B0A-BD80-438A-8051-1304FCFFE598}
+	EndGlobalSection
+EndGlobal

--- a/eventhub-function/eventhub-function.csproj
+++ b/eventhub-function/eventhub-function.csproj
@@ -1,15 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
     <RootNamespace>eventhub_function</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.6" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.28" />
-    <PackageReference Include="Polly" Version="7.1.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Polly" Version="7.1.1" />
     <ProjectReference Include="../circuit-library/circuit-library.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/eventhub-function/local.settings.json.sample
+++ b/eventhub-function/local.settings.json.sample
@@ -4,7 +4,7 @@
       "AzureWebJobsStorage": "<storage connection string>",
       "FUNCTIONS_WORKER_RUNTIME": "dotnet",
       "CircuitRequestUri": "http://myfunction.azurewebsites.net/runtime/webhooks/durabletask/entities/Circuit",
-      "EventHubConnectionString": "<event hub conneciton string>",
+      "EventHubConnectionString": "circuitbreaker-test",
       "ResourceId": "/subscriptions/411a9cd0-1111-1111-1111-cc1ea96a3933/resourceGroups/myResourceGroup/providers/Microsoft.Web/sites/myEventHubFunction"
     }
 }

--- a/eventhub-publisher/Program.cs
+++ b/eventhub-publisher/Program.cs
@@ -11,9 +11,12 @@ namespace publisher_net
     class Program
     {
         private static EventHubClient eventHubClient;
+
         static async Task Main(string[] args)
         {
-            
+            // read environment vars from .env file
+            DotNetEnv.Env.Load();
+
             string eventHubConnectionString = System.Environment.GetEnvironmentVariable("EventHubConnectionString");
             string eventHubName = System.Environment.GetEnvironmentVariable("EventHubName");
             var connectionStringBuilder = new EventHubsConnectionStringBuilder(eventHubConnectionString) {

--- a/eventhub-publisher/Properties/launchSettings.json
+++ b/eventhub-publisher/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "eventhub-publisher": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/eventhub-publisher/eventhub-publisher.csproj
+++ b/eventhub-publisher/eventhub-publisher.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
+    <PackageReference Include="DotNetEnv" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update=".env">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
addresses https://github.com/jeffhollan/functions-durable-actor-circuitbreaker/issues/1

- upgrade to GA 2.0.0 durable functions
- swap closed for open (logic was reverse of convention)
- add dotnetenv package to parse and load .env for environment variables
- update host.json and sample file
- bugfix: pass passing resourceId instead of instanceId to orchestrator
